### PR TITLE
use dplyr::n()

### DIFF
--- a/R/tabulation.R
+++ b/R/tabulation.R
@@ -70,7 +70,7 @@ rcv_tally <- function(image, rules = c('rcv','stv'), n_winners = 1, rcvcontest) 
       dplyr::filter(vote_rank == min(vote_rank)) %>%
       dplyr::ungroup() %>%
       dplyr::group_by(candidate) %>%
-      dplyr::summarise(total = n()) %>%
+      dplyr::summarise(total = dplyr::n()) %>%
       data.frame() %>%
       dplyr::right_join(candidates,
                  by = c("candidate")) %>%


### PR DESCRIPTION
starting from dplyr 1.0.0 `n()` is no longer special, so you either have to import it into your namespace, or prefix it. In this PR, I've prefixed as it looks more consistent with the rest of the code. 

Please consider releasing `rcv` to CRAN with this change before we release `dplyr` 1.0.0 soon. 